### PR TITLE
Remove hard-to-satisfy coverage check for `LCMMonoid`.

### DIFF
--- a/src/public/Test/QuickCheck/Classes/Monoid/LCM.hs
+++ b/src/public/Test/QuickCheck/Classes/Monoid/LCM.hs
@@ -287,9 +287,6 @@ lcmMonoidLaw_commutativity a b =
         "lcm a b == lcm b a"
         (lcm a b == lcm b a)
     & cover
-        "lcm a b == mempty"
-        (lcm a b == mempty)
-    & cover
         "lcm a b /= mempty"
         (lcm a b /= mempty)
     & report


### PR DESCRIPTION
This PR removes the `lcm a b == mempty` coverage check.
    
Having this coverage check doesn't actually provide much value, as it can only be satisfied when both arguments are `mempty`.
